### PR TITLE
Added some info about the number of hands played, the amount bet and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,12 @@ Any strategy can be fed into the simulator as a .csv file. The default strategy 
 * Sr ... Surrender
 * D ... Double Down
 * P ... Split
+
+### Note on the shuffle method used
+The shuffle method used is the default random.shuffle() which comes with a warning :
+"[if] the total number of permutations of x is larger than the period of most random number generators, [then] most permutations of a long sequence can never be generated."
+https://docs.python.org/2/library/random.html
+Hopefully :
+"Python uses the Mersenne Twister as the core generator. It produces 53-bit precision floats and has a period of 2**19937-1"
+Which means that a list of over ~~2080 elements would never see all its permutations, even if it got shuffled an infinite number of times. 8x52 = 416 is low enough to ignore this problem.
+

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Any strategy can be fed into the simulator as a .csv file. The default strategy 
 * P ... Split
 
 ### Note on the shuffle method used
-The shuffle method used is the default random.shuffle() which comes with a warning :
-"[if] the total number of permutations of x is larger than the period of most random number generators, [then] most permutations of a long sequence can never be generated."
-https://docs.python.org/2/library/random.html
-Hopefully :
+The shuffle method used is the default random.shuffle() which comes with a warning :  
+*"[if] the total number of permutations of x is larger than the period of most random number generators, [then] most permutations of a long sequence can never be generated."*  
+https://docs.python.org/2/library/random.html  
+Hopefully :  
 "Python uses the Mersenne Twister as the core generator. It produces 53-bit precision floats and has a period of 2**19937-1"
 Which means that a list of over ~~2080 elements would never see all its permutations, even if it got shuffled an infinite number of times. 8x52 = 416 is low enough to ignore this problem.
 


### PR DESCRIPTION
…the edge the player has. 
Disabled triple seven blackjack as it doesn't seem to be the most common rule (maybe it should be an option along many other rules variants?).
Disabled the ROUNS_PER_GAME value, now a game ends when the shoe is shuffled. Since the win rate increases and the OMEGA count becomes more impactful as the shoe gets slimmer, this aims at reducing the (small) noise added when the last shoe is not played until the end.
